### PR TITLE
check timeout

### DIFF
--- a/lua/easyformat/config.lua
+++ b/lua/easyformat/config.lua
@@ -56,6 +56,8 @@ end
 
 bt.__index = bt
 
+rawset(config, 'timeout', 100)
+
 function bt.use_default(fts)
   for _, ft in pairs(fts) do
     config[ft] = true
@@ -69,12 +71,20 @@ function bt.__newindex(t, k, v)
   end
   v = type(v) == 'boolean' and {} or v
 
-  conf = vim.tbl_extend('force', conf, v)
-  if vim.fn.executable(conf.cmd) == 0 then
-    vim.notify('[EasyFormat] ' .. config.cmd .. ' not executable', vim.log.levels.Error)
-    return
+  if type(v) == 'table' then
+    conf = vim.tbl_extend('force', conf, v)
+    if not conf.cmd then
+      vim.notify('[EasyFormat] cmd is a necessary key', vim.log.levels.Error)
+      return
+    end
+    if vim.fn.executable(conf.cmd) == 0 then
+      vim.notify('[EasyFormat] ' .. conf.cmd .. ' not executable', vim.log.levels.Error)
+      return
+    end
+    rawset(t, k, conf)
+  else
+    rawset(t, k, v)
   end
-  rawset(t, k, conf)
 end
 
 return setmetatable(config, bt)

--- a/lua/easyformat/config.lua
+++ b/lua/easyformat/config.lua
@@ -70,11 +70,19 @@ function bt.__newindex(t, k, v)
     conf = {}
   end
   v = type(v) == 'boolean' and {} or v
-
-  conf = vim.tbl_extend('force', conf, v)
-  if vim.fn.executable(conf.cmd) == 0 then
-    vim.notify('[EasyFormat] ' .. conf.cmd .. ' not executable', vim.log.levels.Error)
-    return
+  if type(v) == 'table' then
+    conf = vim.tbl_extend('force', conf, v)
+    if not conf.cmd then
+      vim.notify('[EasyFormat] cmd is a necessary key', vim.log.levels.Error)
+      return
+    end
+    if vim.fn.executable(conf.cmd) == 0 then
+      vim.notify('[EasyFormat] ' .. conf.cmd .. ' not executable', vim.log.levels.Error)
+      return
+    end
+    rawset(t, k, conf)
+  else
+    rawset(t, k, v)
   end
 end
 

--- a/lua/easyformat/config.lua
+++ b/lua/easyformat/config.lua
@@ -17,6 +17,14 @@ local function get_builtin(ft)
       fname = true,
       stdin = false,
     },
+    {
+      cmd = 'black',
+      args = {},
+      find = false,
+      fname = true,
+      stdin = false,
+      stdout = true,
+    },
     cpp = {
       cmd = 'clang-format',
       args = { '-style=file' },

--- a/lua/easyformat/config.lua
+++ b/lua/easyformat/config.lua
@@ -72,10 +72,6 @@ function bt.__newindex(t, k, v)
   v = type(v) == 'boolean' and {} or v
   if type(v) == 'table' then
     conf = vim.tbl_extend('force', conf, v)
-    if not conf.cmd then
-      vim.notify('[EasyFormat] cmd is a necessary key', vim.log.levels.Error)
-      return
-    end
     if vim.fn.executable(conf.cmd) == 0 then
       vim.notify('[EasyFormat] ' .. conf.cmd .. ' not executable', vim.log.levels.Error)
       return

--- a/lua/easyformat/format.lua
+++ b/lua/easyformat/format.lua
@@ -95,7 +95,7 @@ function fmt:new_spawn(buf)
     safe_close(handle)
     safe_close(stdout)
     safe_close(stderr)
-    if self[buf].do_not_need_stdout then
+    if self[buf].stdout then
       vim.schedule(function()
         local fd = uv.fs_open(vim.api.nvim_buf_get_name(buf), 'r', 438)
         if not fd then

--- a/lua/easyformat/format.lua
+++ b/lua/easyformat/format.lua
@@ -20,9 +20,9 @@ function fmt:run(chunks, bufnr)
 
   local curr_changedtick = api.nvim_buf_get_changedtick(bufnr)
   if curr_changedtick ~= self[bufnr].initial_changedtick then
-    vim.notify("current buffer is changed during the formatting",vim.log.levels.Error)
-    if vim.fn.input("continue formatting? this will override curent buffer, y/n") ~= 'y' then
-      return 
+    vim.notify('current buffer is changed during the formatting', vim.log.levels.Error)
+    if vim.fn.input('continue formatting? this will override curent buffer, y/n') ~= 'y' then
+      return
     end
   end
 
@@ -106,6 +106,8 @@ function fmt:new_spawn(buf)
         uv.fs_close(fd)
         chunks = { data }
         self:run(chunks, buf)
+        -- NOTE: why we just use :edit command here? the edit will cause lsp/treesitter to reload
+        -- if we use noautocmd edit, the lsp/treesitter will no longer work
       end)
     else
       if #chunks == 0 then

--- a/lua/easyformat/init.lua
+++ b/lua/easyformat/init.lua
@@ -57,7 +57,7 @@ local function do_fmt(buf)
   end
 
   if searcher(conf.find, buf) then
-    if conf.fname then
+    if conf.fname and conf.args[#conf.args] ~= api.nvim_buf_get_name(buf) then
       conf.args[#conf.args + 1] = api.nvim_buf_get_name(buf)
     end
     fmt:init(vim.tbl_extend('keep', conf, { bufnr = buf }))


### PR DESCRIPTION
If the user passes the wrong args to `configs`, it's possible that `EasyFormat` will not respond. This commit will kill the formatter process if it costs more than `timeout`(such as 100ms) and notify the user the check their configs. 